### PR TITLE
Fixed best answer UI on mobile

### DIFF
--- a/less/forum/extension.less
+++ b/less/forum/extension.less
@@ -9,6 +9,17 @@
     margin-top: 35px;
     border-radius: 4px;
 
+    .Post-header > ul {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+
+      .item-meta {
+        flex-grow: 1;
+        text-align: right;
+      }
+    }
+
     .Post-body {
       color: #111;
     }


### PR DESCRIPTION
I noticed that now the there is `"set by {username}"` in the .best answer UI, this would affect the body of the best answer and not display it correctly on mobile.
I made a quick fix using flexbox.
See the Screenshots to see the difference.
Bofore : 
![before](https://i.imgur.com/SDzdmIN.png)
After : 
![after](https://i.imgur.com/KH2QBYZ.png)